### PR TITLE
Fix: IV calculation typo

### DIFF
--- a/contracts/Options/PriceCalculator.sol
+++ b/contracts/Options/PriceCalculator.sol
@@ -152,7 +152,7 @@ contract PriceCalculator is IPriceCalculator, Ownable {
         iv = iv.mul(period.sqrt());
         uint256 utilization = pool.lockedAmount().mul(100e8).div(poolBalance);
         if (utilization > 40e8) {
-            iv = iv.mul(utilization.sub(40e8)).mul(utilizationRate).div(40e16);
+            iv += iv.mul(utilization.sub(40e8)).mul(utilizationRate).div(40e16);
         }
     }
 


### PR DESCRIPTION
There is a typo in the IV calculation that would make the utilization-based IV adjustment discontinuous. See this illustration:

![chart](https://user-images.githubusercontent.com/74162299/109836749-7628ac80-7c7f-11eb-9d97-c69fd86e1adc.png) 
