### PR TITLE
Update PriceCalculator.sol

### DIFF
--- a/contracts/Options/PriceCalculator.sol
+++ b/contracts/Options/PriceCalculator.sol
@@ -128,7 +128,7 @@ contract PriceCalculator is IPriceCalculator, Ownable {
         if (optionType == IHegicOptions.OptionType.Put)
             return
                 amount
-                    .mul(_priceModifier(period))
+                    .mul(_priceModifier(amount, period))
                     .mul(strike)
                     .div(PRICE_DECIMALS)
                     .div(PRICE_DECIMALS)
@@ -136,7 +136,7 @@ contract PriceCalculator is IPriceCalculator, Ownable {
         else if (optionType == IHegicOptions.OptionType.Call)
             return
                 amount
-                    .mul(_priceModifier(period))
+                    .mul(_priceModifier(amount, period))
                     .mul(_currentPrice())
                     .div(strike)
                     .div(PRICE_DECIMALS);

--- a/contracts/Options/PriceCalculator.sol
+++ b/contracts/Options/PriceCalculator.sol
@@ -153,7 +153,9 @@ contract PriceCalculator is IPriceCalculator, Ownable {
         uint256 utilization = (pool.lockedAmount().add(amount)).mul(100e8).div(poolBalance);
         if (utilization > 40e8) {
             uint256 percentAbove = ((pool.lockedAmount().add(amount)).mul(100e8).sub(poolBalance.mul(40e8))).div(amount.mul(100e8));
-            if (percentAbove > 1) percentAbove = 1;
+            if (percentAbove > 1) {
+                percentAbove = 1;
+            }
             iv += iv.mul(utilization.sub(40e8)).mul(utilizationRate).div(40e16).mul(percentAbove);
         }
     }

--- a/contracts/Options/PriceCalculator.sol
+++ b/contracts/Options/PriceCalculator.sol
@@ -150,9 +150,11 @@ contract PriceCalculator is IPriceCalculator, Ownable {
         else if (period < 4 weeks) iv = impliedVolRate[1];
         else iv = impliedVolRate[2];
         iv = iv.mul(period.sqrt());
-        uint256 utilization = pool.lockedAmount().mul(100e8).div(poolBalance);
+        uint256 utilization = (pool.lockedAmount().add(amount)).mul(100e8).div(poolBalance);
         if (utilization > 40e8) {
-            iv += iv.mul(utilization.sub(40e8)).mul(utilizationRate).div(40e16);
+            uint256 percentAbove = ((pool.lockedAmount().add(amount)).mul(100e8).sub(poolBalance.mul(40e8))).div(amount.mul(100e8));
+            if (percentAbove > 1) percentAbove = 1;
+            iv += iv.mul(utilization.sub(40e8)).mul(utilizationRate).div(40e16).mul(percentAbove);
         }
     }
 

--- a/contracts/Options/PriceCalculator.sol
+++ b/contracts/Options/PriceCalculator.sol
@@ -142,7 +142,11 @@ contract PriceCalculator is IPriceCalculator, Ownable {
                     .div(PRICE_DECIMALS);
     }
 
-    function _priceModifier(uint256 amount, uint256 period) internal view returns (uint256 iv) {
+    function _priceModifier(uint256 amount, uint256 period)
+        internal
+        view
+        returns (uint256 iv)
+    {
         uint256 poolBalance = pool.totalBalance();
         require(poolBalance > 0, "Pool is empty");
 
@@ -150,13 +154,22 @@ contract PriceCalculator is IPriceCalculator, Ownable {
         else if (period < 4 weeks) iv = impliedVolRate[1];
         else iv = impliedVolRate[2];
         iv = iv.mul(period.sqrt());
-        uint256 utilization = (pool.lockedAmount().add(amount)).mul(100e8).div(poolBalance);
+        uint256 utilization =
+            (pool.lockedAmount().add(amount)).mul(100e8).div(poolBalance);
         if (utilization > 40e8) {
-            uint256 percentAbove = ((pool.lockedAmount().add(amount)).mul(100e8).sub(poolBalance.mul(40e8))).div(amount.mul(100e8));
-            if (percentAbove > 1) {
-                percentAbove = 1;
-            }
-            iv += iv.mul(utilization.sub(40e8)).mul(utilizationRate).div(40e16).mul(percentAbove);
+            uint256 percentAbove =
+                (
+                    (pool.lockedAmount().add(amount)).mul(100e8).sub(
+                        poolBalance.mul(40e8)
+                    )
+                )
+                    .div(amount.mul(100e8));
+            if (percentAbove > 1) percentAbove = 1;
+            iv += iv
+                .mul(utilization.sub(40e8))
+                .mul(utilizationRate)
+                .div(40e16)
+                .mul(percentAbove);
         }
     }
 

--- a/contracts/Options/PriceCalculator.sol
+++ b/contracts/Options/PriceCalculator.sol
@@ -142,7 +142,10 @@ contract PriceCalculator is IPriceCalculator, Ownable {
                     .div(PRICE_DECIMALS);
     }
 
-    function _priceModifier(uint256 period) internal view returns (uint256 iv) {
+    function _priceModifier(
+        uint256 amount,
+        uint256 period
+    ) internal view returns (uint256 iv) {
         uint256 poolBalance = pool.totalBalance();
         require(poolBalance > 0, "Pool is empty");
 

--- a/contracts/Options/PriceCalculator.sol
+++ b/contracts/Options/PriceCalculator.sol
@@ -142,10 +142,7 @@ contract PriceCalculator is IPriceCalculator, Ownable {
                     .div(PRICE_DECIMALS);
     }
 
-    function _priceModifier(
-        uint256 amount,
-        uint256 period
-    ) internal view returns (uint256 iv) {
+    function _priceModifier(uint256 amount, uint256 period) internal view returns (uint256 iv) {
         uint256 poolBalance = pool.totalBalance();
         require(poolBalance > 0, "Pool is empty");
 


### PR DESCRIPTION
Modify line 153 to include option amount in utilization --> multiplier is now based on the future lockedAmount, not current; this ensures big orders pay their fair share

Declare "percentAbove" variable which calculates the percent of the option amount that lies above 40% utilization mark; "if" statement forces it to be between 0 and 1.  Previously I had included "else if (percentAbove < 0) percentAbove = 0;" but it's redundant because line 154 ensures that can never happen already

Include the percentAbove factor in the iv multiplication line --> any option amount that would bring utilization above 40% is only multiplied by the net amount it does bring over 40%, and not the entire amount of the option.

See conversation between abipup and southseacompany on the Hegic Discord server, v888-1-discussion channel on 3 March 2021 for more details.